### PR TITLE
Convert z-index to number before adding

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -150,8 +150,8 @@
       //Adjust the modal and backdrop z-index; for dealing with multiple modals
       var numModals = Modal.count,
           $backdrop = $('.modal-backdrop:eq('+numModals+')'),
-          backdropIndex = $backdrop.css('z-index'),
-          elIndex = $backdrop.css('z-index');
+          backdropIndex = parseInt($backdrop.css('z-index'),10),
+          elIndex = parseInt($backdrop.css('z-index'), 10);
 
       $backdrop.css('z-index', backdropIndex + numModals);
       this.$el.css('z-index', elIndex + numModals);


### PR DESCRIPTION
I noticed that the z-index for my modals was much larger than expected (ex: 10400) which was causing a rendering problem with a widget I'm using. It turns out it was because the modal count was being concatenated onto the z-index string rather than adding the two numbers together.
