### PR TITLE
Changing order of 'hidden' event triggering and handler installation

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -193,13 +193,13 @@
         return;
       }
 
-      $el.modal('hide');
-
       $el.one('hidden', function() {
         self.remove();
 
         self.trigger('hidden');
       });
+
+      $el.modal('hide');
 
       Modal.count--;
     },


### PR DESCRIPTION
I had the problem that the modal DOM wasn't cleaned up after closing. Swapping these lines fixed this for me. I guess when 'hide' was too fast, the 'hidden' handler wasn't installed yet, and so the elements were not removed.
