### PR TITLE
Allow user to pass options directly to bootstrap-modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Set up the modal with the following options:
 - {Boolean} [options.escape]      Whether the 'esc' key can dismiss the modal- true, but false if options.cancellable is true
 - {Boolean} [options.animate]     Whether to animate in/out. Default: false
 - {Function} [options.template]   Compiled underscore template to override the default one
+- {Object} [options.modalOptions] Options to pass directly to bootstrap.modal. See [bootstrap-modal options](https://github.com/jschr/bootstrap-modal#options)
 
 
 ###modal.open([cb])

--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -152,10 +152,10 @@
           $el = this.$el;
 
       //Create it
-      $el.modal({
+      $el.modal(_.extend({
         keyboard: this.options.allowCancel,
         backdrop: this.options.allowCancel ? true : 'static'
-      });
+      }, this.options.modalOptions));
 
       //Focus OK button
       $el.one('shown', function() {


### PR DESCRIPTION
This simple commit adds the option {options.modalOptions} which is passed directly to bootstrap-modal.

Pull request includes README.md update.
