### PR TITLE
Add package.json & prepare for jam

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       "bootstrap": null
     },
     "shim": {
-      "deps": ["jquery", "underscore", "backbone"],
+      "deps": ["jquery", "underscore", "backbone", "exports"],
       "exports": "Backbone.BootstrapModal"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "jam": {
     "dependencies": {
       "bootstrap": null
-    }
+    },
+    "shim": {
+      "deps": ["jquery", "underscore", "backbone"],
+      "exports": "Backbone.BootstrapModal"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "version": "1.0.0",
   "dependencies": {
-    "backbone": "0.9.10"
+    "backbone": ">=0.9.10"
   },
   "main": "src/backbone.bootstrap-modal.js",
   "jam": {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,6 @@
     "shim": {
       "deps": ["jquery", "underscore", "backbone", "exports"],
       "exports": "Backbone.BootstrapModal"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backbone.bootstrap-modal",
+  "description": "Bootstrap Modal wrapper for use with Backbone",
+  "author": {
+    "name": "Charles Davison"
+  },
+  "version": "1.0.0",
+  "dependencies": {
+    "backbone": "0.9.10"
+  },
+  "main": "src/backbone.bootstrap-modal.js",
+  "jam": {
+    "dependencies": {
+      "bootstrap": null
+    }
+  }
+}


### PR DESCRIPTION
It's a bit of a pain to include this from the current Jam backbone-forms package, particularly without the shim. Maintaining this as a separate package makes sense to me.

If you could publish to jam once this is merged, that'd be appreciated.
