### PR TITLE
Fix an issue where bootstrap-tooltip's 'hidden' event can close the modal.

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -224,7 +224,11 @@
         return;
       }
 
-      $el.one('hidden', function() {
+      $el.one('hidden', function onHidden(e) {
+        // Ignore events propagated from bootstrap tooltips
+        if($(e.target).attr('data-toggle') === 'tooltip'){
+          return $el.one('hidden', onHidden);
+        }
         self.remove();
 
         if (self.options.content && self.options.content.trigger) {

--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -225,8 +225,8 @@
       }
 
       $el.one('hidden', function onHidden(e) {
-        // Ignore events propagated from bootstrap tooltips
-        if($(e.target).attr('data-toggle') === 'tooltip'){
+        // Ignore events propagated from interior objects, like bootstrap tooltips
+        if(e.target !== e.currentTarget){
           return $el.one('hidden', onHidden);
         }
         self.remove();


### PR DESCRIPTION
Bootstrap-tooltip.js fires a 'hidden' event when the tooltip is closed. The bug occurs when a modal contains a tooltip - the 'hidden' event will propagate all the way to the handler bound in this library, which will close the modal.

Since this handler is in place only to catch the 'hidden' event thrown by bootstrap-modal, which always is thrown directly on the modal itself (and therefore e.target === e.currentTarget), I've added a simple check to make sure the source is correct.

The effect is that other plugins used inside the modal will no longer accidentally trigger a close.
