### PR TITLE
Fix for issue #29 - Allow focus on any element in the dialog

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -108,6 +108,7 @@
         allowCancel: true,
         escape: true,
         animate: false,
+        focusElement: null,
         template: template
       }, options);
     },
@@ -162,6 +163,10 @@
         if (self.options.focusOk) {
           $el.find('.btn.ok').focus();
         }
+        
+        if (self.options.focusElement) {
+          $el.find(self.options.focusElement).focus();
+        }
 
         if (self.options.content && self.options.content.trigger) {
           self.options.content.trigger('shown', self);
@@ -195,6 +200,8 @@
             e.which == 27 && self.options.content.trigger('shown', self);
           }
         });
+        
+        $el.trigger('shown');
       }
 
       this.on('cancel', function() {


### PR DESCRIPTION
by a jquery selector.

Trying to implement this, I noticed that the shown is not fired. Have you tried the focusOk recently? So I added manual trigger for the shown: $el.trigger('shown'). Let me know if I missed something.

The new option is: focusElement. focusElement can be any valid jquery selector.
