### PR TITLE
Change default template from a -> button

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -34,10 +34,10 @@
     <div class="modal-footer">\
       <% if (allowCancel) { %>\
         <% if (cancelText) { %>\
-          <a href="#" class="btn cancel">{{cancelText}}</a>\
+          <button href="#" class="btn cancel">{{cancelText}}</button>\
         <% } %>\
       <% } %>\
-      <a href="#" class="btn ok btn-primary">{{okText}}</a>\
+      <button href="#" class="btn ok btn-primary">{{okText}}</button>\
     </div>\
   ');
 


### PR DESCRIPTION
A lot of Bootstrap varied themes will change a, a:hover, and a:visited
to match the theme. Which always throws off the text in the .btn colors
of the modal. The user of backbone.bootstrap-modal can provide a custom
defined template but this increases code bloat where it doesn't seem
necessary.
