### PR TITLE
Add option to toggle display of modal footer & buttons

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -32,14 +32,16 @@
       </div>\
     <% } %>\
     <div class="modal-body">{{content}}</div>\
-    <div class="modal-footer">\
-      <% if (allowCancel) { %>\
-        <% if (cancelText) { %>\
-          <a href="#" class="btn cancel">{{cancelText}}</a>\
+    <% if (showFooter) { %>\
+      <div class="modal-footer">\
+        <% if (allowCancel) { %>\
+          <% if (cancelText) { %>\
+            <a href="#" class="btn cancel">{{cancelText}}</a>\
+          <% } %>\
         <% } %>\
-      <% } %>\
-      <a href="#" class="btn ok btn-primary">{{okText}}</a>\
-    </div>\
+        <a href="#" class="btn ok btn-primary">{{okText}}</a>\
+      </div>\
+    <% } %>\
     </div></div>\
   ');
 
@@ -95,6 +97,7 @@
      * @param {String} [options.title]        Title. Default: none
      * @param {String} [options.okText]       Text for the OK button. Default: 'OK'
      * @param {String} [options.cancelText]   Text for the cancel button. Default: 'Cancel'. If passed a falsey value, the button will be removed
+     * @param {Boolean} [options.showFooter]  Whether the modal footer & buttons is shown. Default: true
      * @param {Boolean} [options.allowCancel  Whether the modal can be closed, other than by pressing OK. Default: true
      * @param {Boolean} [options.escape]      Whether the 'esc' key can dismiss the modal. Default: true, but false if options.cancellable is true
      * @param {Boolean} [options.animate]     Whether to animate in/out. Default: false
@@ -107,6 +110,7 @@
         focusOk: true,
         okCloses: true,
         cancelText: 'Cancel',
+        showFooter: true,
         allowCancel: true,
         escape: true,
         animate: false,


### PR DESCRIPTION
I added an option to toggle the display of the footer so I could use modals purely for display purposes (similar to a lightbox) instead of a dialog. Thought others might find this useful. Open to comments/suggestions!
