### PR TITLE
Fix error when content wasn't set

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -150,7 +150,7 @@
       var $content = this.$content = $el.find('.modal-body')
 
       //Insert the main content if it's a view
-      if (content.$el) {
+      if (content && content.$el) {
         content.render();
         $el.find('.modal-body').html(content.$el);
       }


### PR DESCRIPTION
If content was not set, content.$el gave `TypeError: Cannot read property '$el' of undefined`.
