### PR TITLE
Fixed IE9 issue with event listener not being set up due to sync IE behavior

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -173,12 +173,6 @@
       var self = this,
           $el = this.$el;
 
-      //Create it
-      $el.modal(_.extend({
-        keyboard: this.options.allowCancel,
-        backdrop: this.options.allowCancel ? true : 'static'
-      }, this.options.modalOptions));
-
       //Focus OK button
       $el.one('shown.bs.modal', function() {
         if (self.options.focusOk) {
@@ -191,6 +185,12 @@
 
         self.trigger('shown');
       });
+
+      //Create it
+      $el.modal(_.extend({
+        keyboard: this.options.allowCancel,
+        backdrop: this.options.allowCancel ? true : 'static'
+      }, this.options.modalOptions));
 
       //Adjust the modal and backdrop z-index; for dealing with multiple modals
       var numModals = Modal.count,


### PR DESCRIPTION
See for example http://stackoverflow.com/questions/11801711/show-event-doesnt-fire-in-ie9-using-twitter-bootstrap-modal-in-rails
