### PR TITLE
Fixed escape click event - missing a check of escape option

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -211,7 +211,7 @@
         });
 
         $(document).one('keyup.dismiss.modal', function (e) {
-          e.which == 27 && self.trigger('cancel');
+          e.which == 27 && self.options.escape && self.trigger('cancel');
 
           if (self.options.content && self.options.content.trigger) {
             e.which == 27 && self.options.content.trigger('shown', self);


### PR DESCRIPTION
While clicking ESC, the modal should be closed only if the the escape options is set to true. The code is missing a check of the state of this flag while triggering the "cancel" event caused by a click on ESC button.
