### PR TITLE
Add missing class to cancel button

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -36,7 +36,7 @@
       <div class="modal-footer">\
         <% if (allowCancel) { %>\
           <% if (cancelText) { %>\
-            <a href="#" class="btn cancel">{{cancelText}}</a>\
+            <a href="#" class="btn cancel btn-default">{{cancelText}}</a>\
           <% } %>\
         <% } %>\
         <a href="#" class="btn ok btn-primary">{{okText}}</a>\


### PR DESCRIPTION
BS3 requires class "btn-default" for normal buttons. Otherwise they'll have no border
