### PR TITLE
Pressing Esc triggers "cancel" event

### DIFF
--- a/src/backbone.bootstrap-modal.js
+++ b/src/backbone.bootstrap-modal.js
@@ -214,7 +214,7 @@
           e.which == 27 && self.trigger('cancel');
 
           if (self.options.content && self.options.content.trigger) {
-            e.which == 27 && self.options.content.trigger('shown', self);
+            e.which == 27 && self.options.content.trigger('cancel', self);
           }
         });
       }


### PR DESCRIPTION
When pressing the "Esc" key, no cancel event has been fired, but instead a "shown" event.
